### PR TITLE
Allow Poison ~> 4.0 to be used

### DIFF
--- a/lib/receipt_verifier/client.ex
+++ b/lib/receipt_verifier/client.ex
@@ -2,7 +2,6 @@ defmodule ReceiptVerifier.Client do
   @moduledoc false
 
   alias ReceiptVerifier.Error
-  alias Poison.Parser, as: JSONParser
 
   @endpoints [
     production: 'https://buy.itunes.apple.com/verifyReceipt',
@@ -15,7 +14,7 @@ defmodule ReceiptVerifier.Client do
   @spec request(String.t(), map) :: {:ok, map} | {:error, any}
   def request(receipt, opts) do
     with {:ok, {{_, 200, _}, _, body}} <- do_request(receipt, opts),
-         {:ok, json} <- JSONParser.parse(body) do
+         {:ok, json} <- Poison.decode(body) do
       {:ok, json}
     else
       {:ok, {{_, status_code, msg}, _, _body}} ->

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule ReceiptVerifier.Mixfile do
 
   defp deps do
     [
-      {:poison, "~> 2.0 or ~> 3.0"},
+      {:poison, "~> 2.0 or ~> 3.0 or ~> 4.0"},
       {:dialyxir, "~> 0.5", only: :dev},
       {:exvcr, "~> 0.8", only: :test},
       {:credo, "~> 0.7", only: [:dev, :test]},


### PR DESCRIPTION
I tested with latest Poison 3.x and also forced Poison 4.0.1, tests passing with changes.