### PR TITLE
feat: Add cancellation_date & cancellation_reason to IAPReceipt

### DIFF
--- a/lib/receipt_verifier/receipt/iap_receipt.ex
+++ b/lib/receipt_verifier/receipt/iap_receipt.ex
@@ -13,7 +13,9 @@ defmodule ReceiptVerifier.IAPReceipt do
           original_purchase_date: DateTime.t(),
           is_trial_period: boolean(),
           is_in_intro_offer_period: boolean(),
-          expires_date: DateTime.t()
+          expires_date: DateTime.t(),
+          cancellation_date: DateTime.t(),
+          cancellation_reason: integer
         }
 
   defstruct [
@@ -26,7 +28,9 @@ defmodule ReceiptVerifier.IAPReceipt do
     :original_purchase_date,
     :is_trial_period,
     :is_in_intro_offer_period,
-    :expires_date
+    :expires_date,
+    :cancellation_date,
+    :cancellation_reason
   ]
 
   @doc false
@@ -86,6 +90,26 @@ defmodule ReceiptVerifier.IAPReceipt do
 
   defp do_parse_field({"expires_date_pst", _value}) do
     {:skip, nil}
+  end
+
+  defp do_parse_field({"cancellation_date_ms", value}) do
+    {:cancellation_date, format_datetime(value)}
+  end
+
+  defp do_parse_field({"cancellation_date", _value}) do
+    {:skip, nil}
+  end
+
+  defp do_parse_field({"cancellation_date_pst", _value}) do
+    {:skip, nil}
+  end
+
+  defp do_parse_field({"cancellation_reason", nil}) do
+    {:cancellation_reason, nil}
+  end
+
+  defp do_parse_field({"cancellation_reason", value}) do
+    {:cancellation_reason, String.to_integer(value)}
   end
 
   defp do_parse_field({field, value}) do


### PR DESCRIPTION
The receipt info contains cancellation fields when the order is refunded
```json
{
      "quantity": "1",
      "product_id": "...",
      "transaction_id": "...",
      "original_transaction_id": "...",
      "purchase_date": "2020-12-09 09:23:37 Etc/GMT",
      "purchase_date_ms": "1607505817000",
      "purchase_date_pst": "2020-12-09 01:23:37 America/Los_Angeles",
      "original_purchase_date": "2019-09-15 10:29:32 Etc/GMT",
      "original_purchase_date_ms": "1568543372000",
      "original_purchase_date_pst": "2019-09-15 03:29:32 America/Los_Angeles",
      "expires_date": "2021-12-09 09:23:37 Etc/GMT",
      "expires_date_ms": "1639041817000",
      "expires_date_pst": "2021-12-09 01:23:37 America/Los_Angeles",
      "cancellation_date": "2020-12-11 08:01:07 Etc/GMT",
      "cancellation_date_ms": "1607673667000",
      "cancellation_date_pst": "2020-12-11 00:01:07 America/Los_Angeles",
      "web_order_line_item_id": "...",
      "is_trial_period": "false",
      "is_in_intro_offer_period": "false",
      "cancellation_reason": "0",
      "in_app_ownership_type": "PURCHASED",
      "subscription_group_identifier": "..."
}
```